### PR TITLE
Adds installation directives to wibotic_connector_can CMakeLists.

### DIFF
--- a/wibotic_connector_can/CMakeLists.txt
+++ b/wibotic_connector_can/CMakeLists.txt
@@ -25,3 +25,26 @@ catkin_package(
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+
+#############
+## Install ##
+#############
+
+catkin_install_python(
+  PROGRAMS src/wibotic_connector_can/wiboticros.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(
+  DIRECTORY
+  launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)
+
+install(
+  DIRECTORY
+  src/wibotic_connector_can/uavcan_v0
+  src/wibotic_connector_can/uavcan_v1
+  src/wibotic_connector_can/uavcan_vendor_specific_types
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)


### PR DESCRIPTION
Users that work out of the install space (as opposed to devel space) are currently unable to use the ROS interface provided in this repo. This PR fixes that by adding installation rules to wibotic_connector_can's CMakeLists.